### PR TITLE
fix(demo): update run command in installation verifier

### DIFF
--- a/demos/verify_installation.py
+++ b/demos/verify_installation.py
@@ -6,7 +6,7 @@ This demo tests the installation of SIC on your machine.
 Note that it only tests the installation of redis and SIC's basic sending and receiving of messages.
 
 Don't forget to start redis in the framework folder with `redis-server conf/redis/redis.conf` in a separate terminal.
-Don't forget to run `python verify_installation/verify_installation.py` in a separate terminal.
+Don't forget to run `venv_sic/bin/run-verifier` in a separate terminal.
 Then, run this file with `python verify_installation.py`
 
 On success, "Installation successful!" is displayed in your terminal.


### PR DESCRIPTION
Updated the command to run the installation verifier script to `venv_sic/bin/run-verifier` for better clarity and consistency. This ensures users follow the correct procedure for verification.