### PR TITLE
MacOS compatible and changed IP to localhost for Redis script.

### DIFF
--- a/redis_connection_verifier.sh
+++ b/redis_connection_verifier.sh
@@ -18,9 +18,17 @@
 # 2. Execute the script by running:
 #    ./redis_connection_verifier.sh
 
-REDIS_HOST="192.168.2.1" # Change this to where your Redis server is running
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "MacOS"
+    if ! command -v gtimeout &> /dev/null; then
+        echo "Installing coreutils"
+        brew install coreutils
+    fi
+fi
+
+REDIS_HOST="localhost" # Change this to where your Redis server is running
 REDIS_PORT="6379"
-REDIS_PASSWORD="changemeplease"
+REDIS_PASSWORD="changemeplease"  # <- DO NOT CHANGE THIS
 
 # Check if the Redis host is even reachable
 if ! ping -c 1 -W 2 $REDIS_HOST > /dev/null 2>&1; then


### PR DESCRIPTION
1. This commit changes the IP address to localhost, so students do not have to change the IP manually. I think this change should not cause any issues.

2. It fixes a dependency problem for MacOS which needs `coreutils` package from brew before being able to run the `timeout` command.