### PR TITLE
restart Alphamini SSH daemon util

### DIFF
--- a/utils/alphamini_restart_ssh.py
+++ b/utils/alphamini_restart_ssh.py
@@ -1,0 +1,72 @@
+"""
+Utility script for manual AlphaMini SSH daemon lifecycle testing.
+
+Purpose:
+1) Manually restart SSH daemon behavior without SSH access:
+   by sending a simple command through `mini.pkg_tool.run_py_pkg(...)`, we force
+   the robot-side execution path to start a new shell context. In environments
+   where shell startup triggers `sshd`, this acts as a lightweight manual
+   recovery path for SSH availability.
+2) Provide a way to kill the SSH daemon:
+   with the kill flag, operators can stop `sshd` on demand and then verify that
+   the Alphamini device recovery logic (restart-before-reinstall) behaves as
+   expected.
+"""
+
+import argparse
+
+import mini.pkg_tool as Tool
+import mini.mini_sdk as MiniSdk
+MiniSdk.set_robot_type(MiniSdk.RobotType.EDU)
+
+def _run_check(robot_id: str, check_name: str, command: str) -> None:
+    """Send one run_py_pkg command to the target robot and print context."""
+    print(f"\n=== {check_name} ===")
+    print("Command sent through Tool.run_py_pkg:")
+    print(command)
+    Tool.run_py_pkg(command, robot_id=robot_id, debug=True)
+
+
+def main() -> None:
+    """CLI entry point for kill/restart-style SSH daemon recovery checks."""
+    parser = argparse.ArgumentParser(
+        description="Utility script for manual AlphaMini SSH daemon lifecycle testing."
+    )
+    parser.add_argument(
+        "--mini-id",
+        required=True,
+        help="Last 5 digits of AlphaMini serial number (robot_id used by mini SDK).",
+    )
+    parser.add_argument(
+        "--kill-sshd",
+        action="store_true",
+        help="Kill SSH daemon.",
+    )
+    args = parser.parse_args()
+
+    print("Starting AlphaMini SSH daemon diagnostics via run_py_pkg (no SSH).")
+    print(f"Target mini_id: {args.mini_id}")
+
+    if args.kill_sshd:
+        _run_check(
+            robot_id=args.mini_id,
+            check_name="Kill sshd",
+            command="pkill -f sshd",
+        )
+        print("\nDone. sshd kill command sent. Re-run this script without --kill-sshd to verify status.")
+        return
+
+    # Simple command to start a shell (and the SSH daemon again)
+    _run_check(
+        robot_id=args.mini_id,
+        check_name="Simple echo hello",
+        command=(
+            "if echo hello >/dev/null 2>&1; then exit 0; else exit 21; fi"
+        ),
+    )
+
+    print("\nDone. SSH daemon should be running now.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Issue number: resolves N/A
---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
There is no dedicated utility in ``sic_applications`` to manually trigger
AlphaMini SSH daemon recovery without opening an SSH session, or to intentionally
stop ``sshd`` for recovery-path testing.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Adds ``utils/alphamini_restart_ssh.py`` as a lightweight operational helper.
- Supports restarting SSH recovery behavior by sending a simple ``run_py_pkg``
  command (which can re-trigger ``sshd`` startup in affected environments).
- Supports ``--kill-sshd`` to intentionally stop the daemon so users can verify
  recovery logic in ``Alphamini`` (restart-first, reinstall-last).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- Script usage examples:
  - Recover daemon: ``python sic_applications/utils/alphamini_restart_ssh.py --mini-id <mini-id>``
  - Kill daemon: ``python sic_applications/utils/alphamini_restart_ssh.py --mini-id <mini-id> --kill-sshd``
