### PR TITLE
Feature/elevenlabs tts demo

### DIFF
--- a/demos/alphamini/demo_alphamini_elevenlabs_tts.py
+++ b/demos/alphamini/demo_alphamini_elevenlabs_tts.py
@@ -2,19 +2,13 @@ import os
 from os.path import abspath, dirname, join
 
 from dotenv import load_dotenv
-
 from sic_framework.core import sic_logging
 from sic_framework.core.message_python2 import AudioRequest
 from sic_framework.core.sic_application import SICApplication
-
 from sic_framework.devices.alphamini import Alphamini
 from sic_framework.devices.common_mini.mini_speaker import MiniSpeakersConf
-
 from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
-    ElevenLabsTTS,
-    ElevenLabsTTSConf,
-    GetElevenLabsSpeechRequest,
-)
+    ElevenLabsTTS, ElevenLabsTTSConf, GetElevenLabsSpeechRequest)
 
 
 class AlphaminiElevenLabsTTSDemo(SICApplication):

--- a/demos/alphamini/demo_alphamini_elevenlabs_tts.py
+++ b/demos/alphamini/demo_alphamini_elevenlabs_tts.py
@@ -1,0 +1,99 @@
+import os
+from os.path import abspath, dirname, join
+
+from dotenv import load_dotenv
+
+from sic_framework.core import sic_logging
+from sic_framework.core.message_python2 import AudioRequest
+from sic_framework.core.sic_application import SICApplication
+
+from sic_framework.devices.alphamini import Alphamini
+from sic_framework.devices.common_mini.mini_speaker import MiniSpeakersConf
+
+from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
+    ElevenLabsTTS,
+    ElevenLabsTTSConf,
+    GetElevenLabsSpeechRequest,
+)
+
+
+class AlphaminiElevenLabsTTSDemo(SICApplication):
+    """
+    Alphamini ElevenLabs Text-to-Speech demo application.
+    Demonstrates how to use the ElevenLabs TTS service to have the Alphamini speak.
+
+    Requirements:
+    1. ElevenLabs TTS service must be installed and running
+    2. ELEVENLABS_API_KEY must be set in the environment,
+       or passed directly via the api_key constructor argument
+    """
+
+    def __init__(self, api_key=None, mode="batch"):
+        super(AlphaminiElevenLabsTTSDemo, self).__init__()
+
+        self.mini_ip = "10.0.0.211"
+        self.mini_id = "00039"
+        self.mini_password = "alphago"
+        self.redis_ip = "10.0.0.177"
+
+        self.mini = None
+        self.tts = None
+        self._provided_api_key = api_key
+        self.mode = mode
+
+        self.set_log_level(sic_logging.INFO)
+        self.setup()
+
+    def setup(self):
+        self.logger.info("Setting up ElevenLabs Text-to-Speech...")
+
+        load_dotenv(abspath(join(dirname(__file__), "..", "..", "conf", ".env")))
+        self.api_key = self._provided_api_key or os.getenv("ELEVENLABS_API_KEY")
+
+        if not self.api_key:
+            raise ValueError("No ElevenLabs API key found. Set ELEVENLABS_API_KEY.")
+
+        tts_conf = ElevenLabsTTSConf(
+            api_key=self.api_key,
+            default_mode=self.mode,
+            # optional overrides:
+            # voice_id="yO6w2xlECAQRFP6pX7Hw",
+            # model_id="eleven_flash_v2_5",
+            # sample_rate=22050,
+        )
+        self.tts = ElevenLabsTTS(conf=tts_conf)
+
+    def run(self):
+        self.logger.info("Starting Alphamini ElevenLabs TTS Demo")
+
+        try:
+            reply = self.tts.request(
+                GetElevenLabsSpeechRequest(
+                    text="Hello, I am an Alphamini robot testing the ElevenLabs text to speech service in Social Interaction Cloud. This is a slightly longer example so we can check whether the full audio plays correctly from beginning to end. If everything is working well, there should be no truncation, no missing words, and the voice should sound natural.",
+                    mode="batch",
+                )
+            )
+
+            self.logger.info("Initializing Alphamini...")
+            self.mini = Alphamini(
+                ip=self.mini_ip,
+                mini_id=self.mini_id,
+                mini_password=self.mini_password,
+                redis_ip=self.redis_ip,
+                speaker_conf=MiniSpeakersConf(sample_rate=reply.sample_rate),
+            )
+
+            self.logger.info("Alphamini speaking...")
+            self.mini.speaker.request(AudioRequest(reply.waveform, reply.sample_rate))
+
+            self.logger.info("Speech playback completed")
+
+        except Exception as e:
+            self.logger.error("Exception: {}".format(e))
+        finally:
+            self.shutdown()
+
+
+if __name__ == "__main__":
+    demo = AlphaminiElevenLabsTTSDemo(mode="ws")
+    demo.run()

--- a/demos/alphamini/demo_alphamini_elevenlabs_tts.py
+++ b/demos/alphamini/demo_alphamini_elevenlabs_tts.py
@@ -14,7 +14,8 @@ from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
 class AlphaminiElevenLabsTTSDemo(SICApplication):
     """
     Alphamini ElevenLabs Text-to-Speech demo application.
-    Demonstrates how to use the ElevenLabs TTS service to have the Alphamini speak.
+    Demonstrates how to use the ElevenLabs TTS service to have the Alphamini
+    speak.
 
     Requirements:
     1. ElevenLabs TTS service must be installed and running
@@ -41,11 +42,17 @@ class AlphaminiElevenLabsTTSDemo(SICApplication):
     def setup(self):
         self.logger.info("Setting up ElevenLabs Text-to-Speech...")
 
-        load_dotenv(abspath(join(dirname(__file__), "..", "..", "conf", ".env")))
-        self.api_key = self._provided_api_key or os.getenv("ELEVENLABS_API_KEY")
+        load_dotenv(
+            abspath(join(dirname(__file__), "..", "..", "conf", ".env"))
+        )
+        self.api_key = (
+            self._provided_api_key or os.getenv("ELEVENLABS_API_KEY")
+        )
 
         if not self.api_key:
-            raise ValueError("No ElevenLabs API key found. Set ELEVENLABS_API_KEY.")
+            raise ValueError(
+                "No ElevenLabs API key found. Set ELEVENLABS_API_KEY."
+            )
 
         tts_conf = ElevenLabsTTSConf(
             api_key=self.api_key,
@@ -63,7 +70,16 @@ class AlphaminiElevenLabsTTSDemo(SICApplication):
         try:
             reply = self.tts.request(
                 GetElevenLabsSpeechRequest(
-                    text="Hello, I am an Alphamini robot testing the ElevenLabs text to speech service in Social Interaction Cloud. This is a slightly longer example so we can check whether the full audio plays correctly from beginning to end. If everything is working well, there should be no truncation, no missing words, and the voice should sound natural.",
+                    text=(
+                        "Hello, I am an Alphamini robot testing the"
+                        " ElevenLabs text to speech service in Social"
+                        " Interaction Cloud. This is a slightly longer"
+                        " example so we can check whether the full audio"
+                        " plays correctly from beginning to end. If"
+                        " everything is working well, there should be no"
+                        " truncation, no missing words, and the voice"
+                        " should sound natural."
+                    ),
                     mode="batch",
                 )
             )
@@ -78,7 +94,9 @@ class AlphaminiElevenLabsTTSDemo(SICApplication):
             )
 
             self.logger.info("Alphamini speaking...")
-            self.mini.speaker.request(AudioRequest(reply.waveform, reply.sample_rate))
+            self.mini.speaker.request(
+                AudioRequest(reply.waveform, reply.sample_rate)
+            )
 
             self.logger.info("Speech playback completed")
 

--- a/demos/desktop/demo_desktop_elevenlabs_tts.py
+++ b/demos/desktop/demo_desktop_elevenlabs_tts.py
@@ -3,11 +3,16 @@ import os
 from sic_framework.core import sic_logging
 from sic_framework.core.message_python2 import AudioRequest
 from sic_framework.core.sic_application import SICApplication
+
 from sic_framework.devices.common_desktop.desktop_speakers import SpeakersConf
 from sic_framework.devices.desktop import Desktop
+
 from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
-    ElevenLabsSpeechResult, ElevenLabsTTS, ElevenLabsTTSConf,
-    GetElevenLabsSpeechRequest)
+    ElevenLabsTTS,
+    ElevenLabsTTSConf,
+    GetElevenLabsSpeechRequest,
+    ElevenLabsSpeechResult,
+)
 
 
 class ElevenLabsTTSDemo(SICApplication):

--- a/demos/desktop/demo_desktop_elevenlabs_tts.py
+++ b/demos/desktop/demo_desktop_elevenlabs_tts.py
@@ -3,16 +3,11 @@ import os
 from sic_framework.core import sic_logging
 from sic_framework.core.message_python2 import AudioRequest
 from sic_framework.core.sic_application import SICApplication
-
 from sic_framework.devices.common_desktop.desktop_speakers import SpeakersConf
 from sic_framework.devices.desktop import Desktop
-
 from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
-    ElevenLabsTTS,
-    ElevenLabsTTSConf,
-    GetElevenLabsSpeechRequest,
-    ElevenLabsSpeechResult,
-)
+    ElevenLabsSpeechResult, ElevenLabsTTS, ElevenLabsTTSConf,
+    GetElevenLabsSpeechRequest)
 
 
 class ElevenLabsTTSDemo(SICApplication):

--- a/demos/desktop/demo_desktop_elevenlabs_tts.py
+++ b/demos/desktop/demo_desktop_elevenlabs_tts.py
@@ -11,6 +11,7 @@ from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
     ElevenLabsTTS,
     ElevenLabsTTSConf,
     GetElevenLabsSpeechRequest,
+    ElevenLabsSpeechResult,
 )
 
 

--- a/demos/desktop/demo_desktop_elevenlabs_tts.py
+++ b/demos/desktop/demo_desktop_elevenlabs_tts.py
@@ -11,7 +11,6 @@ from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
     ElevenLabsTTS,
     ElevenLabsTTSConf,
     GetElevenLabsSpeechRequest,
-    ElevenLabsSpeechResult,
 )
 
 

--- a/demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py
+++ b/demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py
@@ -1,0 +1,183 @@
+import os
+import queue
+import re
+import threading
+from os import environ
+from os.path import abspath, dirname, join
+
+from dotenv import load_dotenv
+
+from sic_framework.core import sic_logging
+from sic_framework.core.message_python2 import AudioRequest
+from sic_framework.core.sic_application import SICApplication
+from sic_framework.devices.common_desktop.desktop_speakers import SpeakersConf
+from sic_framework.devices.desktop import Desktop
+from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
+    ElevenLabsTTS,
+    ElevenLabsTTSConf,
+    GetElevenLabsSpeechRequest,
+)
+from sic_framework.services.llm import GPT, GPTConf, GPTRequest
+
+# Matches whitespace following a sentence-ending punctuation mark
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+
+SAMPLE_RATE = 22050
+
+
+class GPTElevenLabsStreamingDemo(SICApplication):
+    """
+    Streaming demo: GPT token stream -> ElevenLabs TTS -> Desktop speakers.
+
+    As GPT streams tokens, complete sentences are detected and sent to
+    ElevenLabs immediately for synthesis, so audio playback starts before
+    GPT has finished generating the full response.
+
+    Requirements:
+    1. ElevenLabs TTS service must be installed and running
+    2. OpenAI GPT service must be running: run-gpt
+    3. OPENAI_API_KEY and ELEVENLABS_API_KEY must be set (env or .env file)
+    """
+
+    def __init__(self, api_key=None, env_path=None):
+        super(GPTElevenLabsStreamingDemo, self).__init__()
+
+        self.env_path = env_path
+        self._provided_api_key = api_key
+
+        self.gpt = None
+        self.tts = None
+        self.desktop = None
+
+        self._text_buffer = ""
+        self._sentence_queue = queue.Queue()
+        self._gpt_done = threading.Event()
+
+        self.set_log_level(sic_logging.INFO)
+        self.setup()
+
+    def setup(self):
+        if self.env_path:
+            load_dotenv(self.env_path)
+
+        self.api_key = self._provided_api_key or os.getenv("ELEVENLABS_API_KEY")
+
+        if not self.api_key:
+            raise ValueError("No ElevenLabs API key found. Set ELEVENLABS_API_KEY.")
+
+        self.desktop = Desktop(speakers_conf=SpeakersConf(sample_rate=SAMPLE_RATE))
+
+        tts_conf = ElevenLabsTTSConf(
+            api_key=self.api_key,
+            default_mode="ws",
+            sample_rate=SAMPLE_RATE,
+        )
+        self.tts = ElevenLabsTTS(conf=tts_conf)
+
+        conf = GPTConf(
+            openai_key=environ["OPENAI_API_KEY"],
+            system_message="You are a helpful assistant. Keep responses concise.",
+            model="gpt-4o-mini",
+            max_tokens=300,
+        )
+        self.gpt = GPT(conf=conf)
+        self.gpt.register_callback(self._on_stream_chunk)
+
+    def _on_stream_chunk(self, message):
+        """
+        Fires for every GPT response event.
+
+        Intermediate chunks (is_stream_chunk=True) are buffered and split
+        on sentence boundaries. The final event flushes any remaining text.
+        """
+        if not hasattr(message, "response"):
+            return
+
+        is_chunk = getattr(message, "is_stream_chunk", False)
+
+        if is_chunk:
+            print(message.response, end="", flush=True)
+            self._text_buffer += message.response
+
+            # Split on sentence boundaries; keep the trailing incomplete fragment
+            parts = _SENTENCE_BOUNDARY.split(self._text_buffer)
+            for sentence in parts[:-1]:
+                sentence = sentence.strip()
+                if sentence:
+                    self._sentence_queue.put(sentence)
+            self._text_buffer = parts[-1]
+        else:
+            # Stream finished — flush whatever is left in the buffer
+            remainder = self._text_buffer.strip()
+            if remainder:
+                self._sentence_queue.put(remainder)
+            self._text_buffer = ""
+            print()
+            self._gpt_done.set()
+
+    def _speak_sentences(self):
+        """Worker thread: synthesize and play each queued sentence in order."""
+        while True:
+            try:
+                sentence = self._sentence_queue.get(timeout=0.1)
+            except queue.Empty:
+                if self._gpt_done.is_set() and self._sentence_queue.empty():
+                    break
+                continue
+
+            self.logger.info("Speaking: {}".format(sentence))
+            try:
+                reply = self.tts.request(
+                    GetElevenLabsSpeechRequest(text=sentence, mode="batch")
+                )
+                self.logger.info("Got {} bytes, playing audio...".format(len(reply.waveform)))
+                self.desktop.speakers.request(
+                    AudioRequest(reply.waveform, reply.sample_rate)
+                )
+                self.logger.info("Playback done.")
+            except Exception as e:
+                self.logger.error("TTS error: {}".format(e))
+
+    def run(self):
+        self.logger.info("GPT + ElevenLabs Streaming Demo. Type 'quit' to exit.")
+
+        try:
+            while not self.shutdown_event.is_set():
+                user_input = input("You: ").strip()
+                if user_input.lower() in {"quit", "exit", "q"}:
+                    break
+                if not user_input:
+                    continue
+
+                # Reset per-turn state
+                self._text_buffer = ""
+                self._gpt_done.clear()
+                while not self._sentence_queue.empty():
+                    try:
+                        self._sentence_queue.get_nowait()
+                    except queue.Empty:
+                        break
+
+                # Audio player starts immediately and consumes sentences as they arrive
+                audio_thread = threading.Thread(
+                    target=self._speak_sentences, daemon=True
+                )
+                audio_thread.start()
+
+                print("AI: ", end="", flush=True)
+                self.gpt.request(GPTRequest(prompt=user_input, stream=True))
+
+                # Wait for all audio to finish before next turn
+                audio_thread.join()
+
+        except Exception as e:
+            self.logger.error("Exception: {}".format(e))
+        finally:
+            self.shutdown()
+
+
+if __name__ == "__main__":
+    demo = GPTElevenLabsStreamingDemo(
+        env_path=abspath(join(dirname(__file__), "..", "..", "conf", ".env"))
+    )
+    demo.run()

--- a/demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py
+++ b/demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py
@@ -56,12 +56,18 @@ class GPTElevenLabsStreamingDemo(SICApplication):
         if self.env_path:
             load_dotenv(self.env_path)
 
-        self.api_key = self._provided_api_key or os.getenv("ELEVENLABS_API_KEY")
+        self.api_key = (
+            self._provided_api_key or os.getenv("ELEVENLABS_API_KEY")
+        )
 
         if not self.api_key:
-            raise ValueError("No ElevenLabs API key found. Set ELEVENLABS_API_KEY.")
+            raise ValueError(
+                "No ElevenLabs API key found. Set ELEVENLABS_API_KEY."
+            )
 
-        self.desktop = Desktop(speakers_conf=SpeakersConf(sample_rate=SAMPLE_RATE))
+        self.desktop = Desktop(
+            speakers_conf=SpeakersConf(sample_rate=SAMPLE_RATE)
+        )
 
         tts_conf = ElevenLabsTTSConf(
             api_key=self.api_key,
@@ -72,7 +78,9 @@ class GPTElevenLabsStreamingDemo(SICApplication):
 
         conf = GPTConf(
             openai_key=environ["OPENAI_API_KEY"],
-            system_message="You are a helpful assistant. Keep responses concise.",
+            system_message=(
+                "You are a helpful assistant. Keep responses concise."
+            ),
             model="gpt-4o-mini",
             max_tokens=300,
         )
@@ -95,7 +103,7 @@ class GPTElevenLabsStreamingDemo(SICApplication):
             print(message.response, end="", flush=True)
             self._text_buffer += message.response
 
-            # Split on sentence boundaries; keep the trailing incomplete fragment
+            # Split on sentence boundaries; keep trailing incomplete fragment
             parts = _SENTENCE_BOUNDARY.split(self._text_buffer)
             for sentence in parts[:-1]:
                 sentence = sentence.strip()
@@ -126,7 +134,11 @@ class GPTElevenLabsStreamingDemo(SICApplication):
                 reply = self.tts.request(
                     GetElevenLabsSpeechRequest(text=sentence, mode="batch")
                 )
-                self.logger.info("Got {} bytes, playing audio...".format(len(reply.waveform)))
+                self.logger.info(
+                    "Got {} bytes, playing audio...".format(
+                        len(reply.waveform)
+                    )
+                )
                 self.desktop.speakers.request(
                     AudioRequest(reply.waveform, reply.sample_rate)
                 )
@@ -135,7 +147,9 @@ class GPTElevenLabsStreamingDemo(SICApplication):
                 self.logger.error("TTS error: {}".format(e))
 
     def run(self):
-        self.logger.info("GPT + ElevenLabs Streaming Demo. Type 'quit' to exit.")
+        self.logger.info(
+            "GPT + ElevenLabs Streaming Demo. Type 'quit' to exit."
+        )
 
         try:
             while not self.shutdown_event.is_set():
@@ -154,7 +168,7 @@ class GPTElevenLabsStreamingDemo(SICApplication):
                     except queue.Empty:
                         break
 
-                # Audio player starts immediately and consumes sentences as they arrive
+                # Audio thread starts immediately, consumes queued sentences
                 audio_thread = threading.Thread(
                     target=self._speak_sentences, daemon=True
                 )

--- a/demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py
+++ b/demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py
@@ -6,17 +6,13 @@ from os import environ
 from os.path import abspath, dirname, join
 
 from dotenv import load_dotenv
-
 from sic_framework.core import sic_logging
 from sic_framework.core.message_python2 import AudioRequest
 from sic_framework.core.sic_application import SICApplication
 from sic_framework.devices.common_desktop.desktop_speakers import SpeakersConf
 from sic_framework.devices.desktop import Desktop
 from sic_framework.services.elevenlabs_tts.elevenlabs_tts import (
-    ElevenLabsTTS,
-    ElevenLabsTTSConf,
-    GetElevenLabsSpeechRequest,
-)
+    ElevenLabsTTS, ElevenLabsTTSConf, GetElevenLabsSpeechRequest)
 from sic_framework.services.llm import GPT, GPTConf, GPTRequest
 
 # Matches whitespace following a sentence-ending punctuation mark


### PR DESCRIPTION
## Summary
- Added AlphaMini ElevenLabs TTS demo: connects to the AlphaMini robot and uses ElevenLabs to synthesize and play speech
- Added GPT + ElevenLabs streaming demo: streams GPT token output sentence-by-sentence into ElevenLabs TTS so audio starts playing before GPT finishes generating
- Removed unused `ElevenLabsSpeechResult` import from existing desktop TTS demo (cleanup only)

## Changes
- `demos/alphamini/demo_alphamini_elevenlabs_tts.py` — new file
- `demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py` — new file
- `demos/desktop/demo_desktop_elevenlabs_tts.py` — minor cleanup (removed unused import)

## How to test
1. Start Redis: `redis-server`
2. Start ElevenLabs TTS service: `run-elevenlabs-tts`
3. For streaming demo, also start GPT service: `run-gpt`
4. Run the desired demo: `python demos/desktop/demo_desktop_gpt_elevenlabs_streaming.py`

## Notes
- Requires `ELEVENLABS_API_KEY` and `OPENAI_API_KEY` set in `conf/.env`
- AlphaMini demo requires the robot to be on the same network
)"